### PR TITLE
change _relatedErrors from private to protected

### DIFF
--- a/RelatedBehavior.php
+++ b/RelatedBehavior.php
@@ -18,7 +18,7 @@ class RelatedBehavior extends \yii\base\Behavior
     public $beforeRSave;
     public $afterRSave;
     public $clearError = true;
-    private $_relatedErrors = [];
+    protected $_relatedErrors = [];
 
     /**
      *


### PR DESCRIPTION
to be accessible from an extended class
